### PR TITLE
Update docs on pages prop typo

### DIFF
--- a/guide/configue-stickyroll/Readme.md
+++ b/guide/configue-stickyroll/Readme.md
@@ -40,7 +40,7 @@ In this example we want to double the amount so the timeline is longer.
 We have add an attribute to `Stickyroll`.
 
 ```jsx
-<Stickyroll page={headlines} factor={2}/>
+<Stickyroll pages={headlines} factor={2}/>
 ```
 
 Play around with this option until you have the effect that suits you best.
@@ -59,7 +59,7 @@ will help prevent unneeded computations.
 We have add an attribute to `Stickyroll`.
 
 ```jsx
-<Stickyroll page={headlines} factor={2} throttle={250}/>
+<Stickyroll pages={headlines} factor={2} throttle={250}/>
 ```
 
 Now we can the className of our content container based on the progress.  
@@ -109,7 +109,7 @@ a solution that nicely ties into the mechanism.
 We have to add an attribute to `Stickyroll`.
 
 ```jsx
-<Stickyroll page={headlines} anchors=""/>
+<Stickyroll pages={headlines} anchors=""/>
 ```
 
 Setting `anchors` injects elements with corresponding IDs to allow hash navigation.

--- a/guide/creating-plugins/Readme.md
+++ b/guide/creating-plugins/Readme.md
@@ -126,7 +126,7 @@ and add this new snippet
 Now we have to add an attribute to `Stickyroll`. 
 
 ```jsx
-<Stickyroll page={headlines} anchors=""/>
+<Stickyroll pages={headlines} anchors=""/>
 ```
 
 Setting `anchors` injects elements with corresponding IDs to allow hash navigation.


### PR DESCRIPTION
## Motivation
- Guide docs seems to have a typo on the `pages` prop of the example

## Issues closed
<!-- List closed issues here -->


## Compatibility tests
<!-- Checklist -->

- [ ] All tests pass  
- [ ] New test added

## Intended version

- [ ] Major (BREAKING CHANGES)
- [ ] Minor (feat)
- [x] Patch (fix)
